### PR TITLE
Multi-tier review endpoint

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -63,7 +63,11 @@ func UpdateDecision(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id parameter"))
 	}
 
-	existing_decision := service.GetDecision(decision.ID)
+	existing_decision, err := service.GetDecision(decision.ID)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
 
 	if existing_decision.Finalized {
 		json.NewEncoder(w).Encode(existing_decision)
@@ -106,6 +110,10 @@ func FinalizeDecision(w http.ResponseWriter, r *http.Request) {
 	existing_decision.Timestamp = time.Now().Unix()
 
 	err := service.UpdateDecision(existing_decision.ID, existing_decision)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
 
 	updated_decision, err := service.GetDecision(existing_decision.ID)
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -67,7 +67,7 @@ func UpdateDecision(w http.ResponseWriter, r *http.Request) {
 	if decision.ID == "" {
 		panic(errors.UnprocessableError("Must provide id parameter."))
 	}
-// Only affects the response, not status of the actual decision.
+
 	existing_decision_history, err := service.GetDecision(decision.ID)
 
 	if err != nil {
@@ -113,7 +113,7 @@ func FinalizeDecision(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id parameter to retrieve current decision	"))
 	}
 
-	// Assuming we are working on the current user's decision 
+	// Assuming we are working on the specified user's decision 
 	existing_decision_history, err := service.GetDecision(id)
 
 	// If the decision is NOT already finalized, set it to what was provided in the request body

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -77,7 +77,7 @@ func UpdateDecision(w http.ResponseWriter, r *http.Request) {
 	decision.Reviewer = reviewer_id
 	decision.Timestamp = time.Now().Unix()
 
-	err := service.UpdateDecision(decision.ID, decision)
+	err = service.UpdateDecision(decision.ID, decision)
 
 	if err != nil {
 		panic(errors.UnprocessableError(err.Error()))

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -68,18 +68,25 @@ func UpdateDecision(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id parameter."))
 	}
 
-	existing_decision_history, err := service.GetDecision(decision.ID)
+	has_decision, err := service.HasDecision(decision.ID)
 
 	if err != nil {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	if existing_decision_history.Finalized {
-		panic(errors.UnprocessableError("Cannot modify finalized decisions."))
+	if has_decision {
+		existing_decision_history, err := service.GetDecision(decision.ID)
+	
+		if err != nil {
+			panic(errors.UnprocessableError(err.Error()))
+		}
+
+		if existing_decision_history.Finalized {
+			panic(errors.UnprocessableError("Cannot modify finalized decisions."))
+		}
 	}
 
-	reviewer_id := r.Header.Get("HackIllinois-Identity")
-	decision.Reviewer = reviewer_id
+	decision.Reviewer = r.Header.Get("HackIllinois-Identity")
 	decision.Timestamp = time.Now().Unix()
 	// Finalized is always false, unless explicitly set to true via the appropriate endpoint.
 	decision.Finalized = false

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -33,11 +33,6 @@ func GetDecision(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	// Affects the response, but not the status of the actual decision.
-	if !decision.Finalized {
-		decision.Status = "PENDING"
-	}
-
 	json.NewEncoder(w).Encode(decision)
 }
 
@@ -53,7 +48,7 @@ func GetCurrentDecision(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	// Affects the response, but not the status of the actual decision.
+	// Masks the decision if not finalized
 	if !decision.Finalized {
 		decision.Status = "PENDING"
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -136,8 +136,7 @@ func FinalizeDecision(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			panic(errors.UnprocessableError("Error updating the decision, in an attempt to finalize it."))
 		}
-	}
-	else {
+	} else {
 		panic(errors.UnprocessableError("Decision already finalized."))
 	}
 

--- a/docs/Decision.md
+++ b/docs/Decision.md
@@ -9,6 +9,7 @@ Returns the decision stored for the user with the `id` `USERID`.
 Response format:
 ```
 {
+	"finalized": false,
 	"id": "github9279532",
 	"status": "ACCEPTED",
 	"wave": 1,
@@ -16,6 +17,7 @@ Response format:
 	"timestamp": 1526673862,
 	"history": [
 		{
+			"finalized": false,
 			"id": "github9279532",
 			"status": "PENDING",
 			"wave": 0,
@@ -23,6 +25,7 @@ Response format:
 			"timestamp": 1526673845
 		},
 		{
+			"finalized": false,
 			"id": "github9279532",
 			"status": "ACCEPTED",
 			"wave": 1,
@@ -41,6 +44,7 @@ Returns the decision stored for the user associated with the `id` in the given J
 Response format:
 ```
 {
+	"finalized": false,
 	"id": "github9279532",
 	"status": "ACCEPTED",
 	"wave": 1,
@@ -48,6 +52,7 @@ Response format:
 	"timestamp": 1526673862,
 	"history": [
 		{
+			"finalized": false,
 			"id": "github9279532",
 			"status": "PENDING",
 			"wave": 0,
@@ -55,6 +60,7 @@ Response format:
 			"timestamp": 1526673845
 		},
 		{
+			"finalized": false,
 			"id": "github9279532",
 			"status": "ACCEPTED",
 			"wave": 1,
@@ -73,6 +79,7 @@ Updates the decision for the user as specified in the `id` field of the request.
 Request format:
 ```
 {
+	"finalized": false,
 	"id": "github9279532",
 	"status": "ACCEPTED",
 	"wave": 1
@@ -82,6 +89,60 @@ Request format:
 Response format:
 ```
 {
+	"finalized": false,
+	"id": "github9279532",
+	"status": "ACCEPTED",
+	"wave": 1,
+	"reviewer": "github9279532",
+	"timestamp": 1526673862,
+	"history": [
+		{
+			"finalized": false,
+			"id": "github9279532",
+			"status": "PENDING",
+			"wave": 0,
+			"reviewer": "github9279532",
+			"timestamp": 1526673845
+		},
+		{
+			"finalized": false,
+			"id": "github9279532",
+			"status": "ACCEPTED",
+			"wave": 1,
+			"reviewer": "github9279532",
+			"timestamp": 1526673862
+		},
+		{
+			"finalized": true,
+			"id": "github9279532",
+			"status": "ACCEPTED",
+			"wave": 1,
+			"reviewer": "github9279532",
+			"timestamp": 1526673862
+		}
+	]
+}
+```
+
+POST /decision/finalize/
+--------------------------
+
+Finalizes the decision for the user as specified in the `id` field of the request. The full decision history is returned in the response. 
+
+Request format:
+```
+{
+	"finalized": false,
+	"id": "github9279532",
+	"status": "ACCEPTED",
+	"wave": 1
+}
+```
+
+Response format:
+```
+{
+	"finalized": true,
 	"id": "github9279532",
 	"status": "ACCEPTED",
 	"wave": 1,

--- a/docs/Decision.md
+++ b/docs/Decision.md
@@ -127,15 +127,12 @@ Response format:
 POST /decision/finalize/
 --------------------------
 
-Finalizes the decision for the user as specified in the `id` field of the request. The full decision history is returned in the response. 
+Finalizes the decision for the current user. The full decision history is returned in the response. 
 
 Request format:
 ```
 {
 	"finalized": false,
-	"id": "github9279532",
-	"status": "ACCEPTED",
-	"wave": 1
 }
 ```
 

--- a/docs/Decision.md
+++ b/docs/Decision.md
@@ -132,7 +132,8 @@ Finalizes the decision for the current user. The full decision history is return
 Request format:
 ```
 {
-	"finalized": false,
+	"id": "github9279532",
+	"finalized": false
 }
 ```
 

--- a/models/decision.go
+++ b/models/decision.go
@@ -1,7 +1,7 @@
 package models
 
 type Decision struct {
-	Finalized bool   `json:"finalized" validate:"required"`
+	Finalized bool   `json:"finalized"`
 	ID        string `json:"id"        validate:"required"`
 	Status    string `json:"status"    validate:"required,oneof=PENDING REJECTED WAITLISTED ACCEPTED"`
 	Wave      int    `json:"wave"      validate:""`

--- a/models/decision.go
+++ b/models/decision.go
@@ -1,6 +1,7 @@
 package models
 
 type Decision struct {
+	Finalized bool   `json:"finalized" validate:"required"`
 	ID        string `json:"id"        validate:"required"`
 	Status    string `json:"status"    validate:"required,oneof=PENDING REJECTED WAITLISTED ACCEPTED"`
 	Wave      int    `json:"wave"      validate:""`

--- a/models/decision.go
+++ b/models/decision.go
@@ -1,7 +1,7 @@
 package models
 
 type Decision struct {
-	Finalized bool   `json:"finalized  validate:"required|isdefault""`
+	Finalized bool   `json:"finalized" validate:"required|isdefault"`
 	ID        string `json:"id"        validate:"required"`
 	Status    string `json:"status"    validate:"required,oneof=PENDING REJECTED WAITLISTED ACCEPTED"`
 	Wave      int    `json:"wave"      validate:""`

--- a/models/decision.go
+++ b/models/decision.go
@@ -1,7 +1,7 @@
 package models
 
 type Decision struct {
-	Finalized bool   `json:"finalized"`
+	Finalized bool   `json:"finalized  validate:"required|isdefault""`
 	ID        string `json:"id"        validate:"required"`
 	Status    string `json:"status"    validate:"required,oneof=PENDING REJECTED WAITLISTED ACCEPTED"`
 	Wave      int    `json:"wave"      validate:""`

--- a/models/decision_finalized.go
+++ b/models/decision_finalized.go
@@ -1,5 +1,6 @@
 package models
 
 type DecisionFinalized struct {
-	Finalized bool `json:"finalized"`
+	ID          string  `json:"id"`
+	Finalized   bool    `json:"finalized"`
 }

--- a/models/decision_finalized.go
+++ b/models/decision_finalized.go
@@ -1,0 +1,5 @@
+package models
+
+type DecisionFinalized struct {
+	Finalized bool `json:"finalized"`
+}

--- a/models/decision_history.go
+++ b/models/decision_history.go
@@ -1,7 +1,7 @@
 package models
 
 type DecisionHistory struct {
-	Finalized bool       `json:"finalized"`
+	Finalized bool       `json:"finalized" validate:"required|isdefault"`
 	ID        string     `json:"id"`
 	Status    string     `json:"status"`
 	Wave      int        `json:"wave"`

--- a/models/decision_history.go
+++ b/models/decision_history.go
@@ -1,6 +1,7 @@
 package models
 
 type DecisionHistory struct {
+	Finalized bool       `json:"finalized" validate:"required"`
 	ID        string     `json:"id"`
 	Status    string     `json:"status"`
 	Wave      int        `json:"wave"`

--- a/models/decision_history.go
+++ b/models/decision_history.go
@@ -1,7 +1,7 @@
 package models
 
 type DecisionHistory struct {
-	Finalized bool       `json:"finalized" validate:"required"`
+	Finalized bool       `json:"finalized"`
 	ID        string     `json:"id"`
 	Status    string     `json:"status"`
 	Wave      int        `json:"wave"`

--- a/models/decision_history.go
+++ b/models/decision_history.go
@@ -1,7 +1,7 @@
 package models
 
 type DecisionHistory struct {
-	Finalized bool       `json:"finalized" validate:"required|isdefault"`
+	Finalized bool       `json:"finalized"`
 	ID        string     `json:"id"`
 	Status    string     `json:"status"`
 	Wave      int        `json:"wave"`

--- a/service/decision_service.go
+++ b/service/decision_service.go
@@ -95,3 +95,18 @@ func UpdateDecision(id string, decision models.Decision) error {
 
 	return err
 }
+
+/*
+	Checks if a decision with the provided id exists.
+*/
+func HasDecision(id string) (bool, error) {
+	_, err := GetDecision(id)
+
+	if err == nil {
+		return true, nil
+	} else if err == mgo.ErrNotFound {
+		return false, nil
+	} else {
+		return false, err
+	}
+}

--- a/service/decision_service.go
+++ b/service/decision_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+
 	"github.com/HackIllinois/api-commons/database"
 	"github.com/HackIllinois/api-decision/config"
 	"github.com/HackIllinois/api-decision/models"
@@ -75,6 +76,7 @@ func UpdateDecision(id string, decision models.Decision) error {
 		}
 	}
 
+	decision_history.Finalized = decision.Finalized
 	decision_history.Status = decision.Status
 	decision_history.Wave = decision.Wave
 	decision_history.History = append(decision_history.History, decision)

--- a/tests/decision_test.go
+++ b/tests/decision_test.go
@@ -1,12 +1,13 @@
 package tests
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/HackIllinois/api-commons/database"
 	"github.com/HackIllinois/api-decision/config"
 	"github.com/HackIllinois/api-decision/models"
 	"github.com/HackIllinois/api-decision/service"
-	"reflect"
-	"testing"
 )
 
 var db database.MongoDatabase
@@ -26,6 +27,7 @@ func init() {
 */
 func SetupTestDB(t *testing.T) {
 	err := db.Insert("decision", &models.DecisionHistory{
+		Finalized: false,
 		ID:        "testid",
 		Status:    "PENDING",
 		Wave:      0,
@@ -33,6 +35,7 @@ func SetupTestDB(t *testing.T) {
 		Timestamp: 1,
 		History: []models.Decision{
 			models.Decision{
+				Finalized: false,
 				ID:        "testid",
 				Status:    "PENDING",
 				Wave:      0,
@@ -74,6 +77,7 @@ func TestGetDecisionService(t *testing.T) {
 	}
 
 	expected_decision := &models.DecisionHistory{
+		Finalized: false,
 		ID:        "testid",
 		Status:    "PENDING",
 		Wave:      0,
@@ -81,6 +85,7 @@ func TestGetDecisionService(t *testing.T) {
 		Timestamp: 1,
 		History: []models.Decision{
 			models.Decision{
+				Finalized: false,
 				ID:        "testid",
 				Status:    "PENDING",
 				Wave:      0,
@@ -104,6 +109,7 @@ func TestUpdateDecisionService(t *testing.T) {
 	SetupTestDB(t)
 
 	err := service.UpdateDecision("testid", models.Decision{
+		Finalized: false,
 		ID:        "testid",
 		Status:    "ACCEPTED",
 		Wave:      1,
@@ -122,6 +128,7 @@ func TestUpdateDecisionService(t *testing.T) {
 	}
 
 	expected_decision := &models.DecisionHistory{
+		Finalized: false,
 		ID:        "testid",
 		Status:    "ACCEPTED",
 		Wave:      1,
@@ -129,6 +136,7 @@ func TestUpdateDecisionService(t *testing.T) {
 		Timestamp: 2,
 		History: []models.Decision{
 			models.Decision{
+				Finalized: false,
 				ID:        "testid",
 				Status:    "PENDING",
 				Wave:      0,
@@ -136,6 +144,7 @@ func TestUpdateDecisionService(t *testing.T) {
 				Timestamp: 1,
 			},
 			models.Decision{
+				Finalized: false,
 				ID:        "testid",
 				Status:    "ACCEPTED",
 				Wave:      1,


### PR DESCRIPTION
Addresses #2 

Please respond to the concerns I mentioned in a comment on the issue.

- [x] Add a `Finalized` field to `Decision` and `DecisionHistory` structs. (Default value is `false`)
- [x] Add an endpoint to set this Field to `true` which finalizes the decision
- [x] Block further reviews/updates on finalized decisions
- [x] When a user gets their own decision is should appear as `PENDING` until finalized