### PR TITLE
[WIP] Redact decision info

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -34,12 +34,17 @@ func GetCurrentDecision(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	// Masks the decision if not finalized
-	if !decision.Finalized {
-		decision.Status = "PENDING"
+	decision_view := models.DecisionView{
+		ID: decision.ID,
+		Status: decision.Status,
 	}
 
-	json.NewEncoder(w).Encode(decision)
+	// Masks the decision if not finalized
+	if !decision.Finalized {
+		decision_view.Status = "PENDING"
+	}
+
+	json.NewEncoder(w).Encode(decision_view)
 }
 
 /*

--- a/docs/Decision.md
+++ b/docs/Decision.md
@@ -44,30 +44,8 @@ Returns the decision stored for the user associated with the `id` in the given J
 Response format:
 ```
 {
-	"finalized": false,
 	"id": "github9279532",
-	"status": "ACCEPTED",
-	"wave": 1,
-	"reviewer": "github9279532",
-	"timestamp": 1526673862,
-	"history": [
-		{
-			"finalized": false,
-			"id": "github9279532",
-			"status": "PENDING",
-			"wave": 0,
-			"reviewer": "github9279532",
-			"timestamp": 1526673845
-		},
-		{
-			"finalized": false,
-			"id": "github9279532",
-			"status": "ACCEPTED",
-			"wave": 1,
-			"reviewer": "github9279532",
-			"timestamp": 1526673862
-		}
-	]
+	"status": "ACCEPTED"
 }
 ```
 

--- a/models/decision_view.go
+++ b/models/decision_view.go
@@ -1,0 +1,6 @@
+package models
+
+type DecisionView struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}


### PR DESCRIPTION
Addresses #9 

Users are only shown their ID and current decision status when accessing the GET `/decision/` endpoint.